### PR TITLE
temp disable

### DIFF
--- a/src/components/WalletSelect/WalletSelect.js
+++ b/src/components/WalletSelect/WalletSelect.js
@@ -63,8 +63,8 @@ const WalletSelect = (props) => {
   }, [wallet.status])
 
   const connectWallet = async (x) => {
-    await wallet.connect(x.inject)
-    window.localStorage.setItem('lastWallet', x.id)
+    await wallet.connect(x?.inject)
+    window.localStorage.setItem('lastWallet', x?.id)
   }
 
   const resetWallet = async () => {
@@ -96,12 +96,12 @@ const WalletSelect = (props) => {
       wallet.status !== 'connecting'
     ) {
       connectWallet(walletTypes.filter((x) => x.id === 'MM')[0])
-    } else if (
-      window.localStorage.getItem('lastWallet') === 'WC' &&
-      wallet.account === null &&
-      wallet.status !== 'connecting'
-    ) {
-      connectWallet(walletTypes.filter((x) => x.id === 'WC')[0])
+      // } else if (
+      //   window.localStorage.getItem('lastWallet') === 'WC' &&
+      //   wallet.account === null &&
+      //   wallet.status !== 'connecting'
+      // ) {
+      //   connectWallet(walletTypes.filter((x) => x.id === 'WC')[0])
     } else if (
       window.localStorage.getItem('lastWallet') === 'OOT' &&
       wallet.account === null &&
@@ -874,11 +874,11 @@ const WalletSelect = (props) => {
                     size="lg"
                     color="success"
                     type="button"
-                    className="btn btn-info btn-block mt-n3"
+                    className="btn btn-info btn-block mt-n3 p-2"
                     onClick={() => connectWallet(x)}
                   >
                     <Col>
-                      <div className="float-left mt-2 ">
+                      <div className="float-left mt-2 pt-1">
                         {x.title === 'Others' ? t('others') : x.title}
                       </div>
                       <div className="float-right">
@@ -886,7 +886,7 @@ const WalletSelect = (props) => {
                           <Image
                             key={`${x.id}icon${i}`}
                             src={i}
-                            className="px-1 wallet-icons"
+                            className="py-1 wallet-icons"
                           />
                         ))}
                       </div>

--- a/src/components/WalletSelect/walletTypes.js
+++ b/src/components/WalletSelect/walletTypes.js
@@ -1,6 +1,6 @@
 import BinanceChain from '../../assets/icons/BinanceChain.svg'
 import MetaMask from '../../assets/icons/metamask.svg'
-import WalletConnect from '../../assets/icons/WalletConnect.svg'
+// import WalletConnect from '../../assets/icons/WalletConnect.svg'
 import TrustWallet from '../../assets/icons/TrustWallet.svg'
 import MathWallet from '../../assets/icons/MathWallet.svg'
 import TokenPocket from '../../assets/icons/TokenPocket.svg'
@@ -19,17 +19,17 @@ const walletTypes = [
     inject: undefined,
   },
   {
-    id: 'WC',
-    title: 'WalletConnect',
-    icon: [WalletConnect],
-    inject: 'walletconnect',
-  },
-  {
     id: 'OOT',
-    title: 'Others',
-    icon: [TokenPocket, MathWallet, TrustWallet],
+    title: 'Mobile Wallet',
+    icon: [TrustWallet, TokenPocket, MathWallet],
     inject: 'injected',
   },
+  // {
+  //   id: 'WC',
+  //   title: 'WalletConnect',
+  //   icon: [WalletConnect],
+  //   inject: 'walletconnect',
+  // },
 ]
 
 export default walletTypes


### PR DESCRIPTION
WalletConnect appears to work fine; however we need to do some internal community testing before enabling it again to check edge cases

Specifically when you connect WalletConnect and have multiple web3 wallets on the desktop browser that its connected to; im not confident it is handled correctly with metamask/BC chrome ext etc

Confirm all that and then reenable to prevent too much work in the community channel