### PR TITLE
upgrade if 0 not loading

### DIFF
--- a/src/views/pages/Upgrade/Upgrade.js
+++ b/src/views/pages/Upgrade/Upgrade.js
@@ -178,10 +178,7 @@ const Upgrade = () => {
                     {t('claim')}
                   </Col>
                   <Col className="text-end output-card">
-                    {sparta.globalDetails.feeOnTransfer > 0
-                      ? formatFromWei(getClaimAmount())
-                      : 'Loading'}{' '}
-                    SPARTAv2
+                    {formatFromWei(getClaimAmount())} SPARTAv2
                   </Col>
                 </Row>
                 <Row className="my-2">


### PR DESCRIPTION
- changed the upgrade page to show 0.00 instead of 'loading' if the claim amount is <= 0 (appeared to be loading forever if the user had no claim)