### PR TITLE
proper unix time for start of day

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -37,9 +37,17 @@ export const formatDate = (unixTime) => {
 }
 
 export const getUnixStartOfDay = () => {
-  const now = new Date()
-  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const now = new Date().getTime()
+  const startOfDay = now - (now % 86400000)
   const timestamp = startOfDay / 1000
+  return timestamp
+}
+
+export const getUnixEndOfDay = () => {
+  const now = new Date().getTime()
+  const startOfDay = now - (now % 86400000)
+  const endOfDay = startOfDay + 86400000
+  const timestamp = endOfDay / 1000
   return timestamp
 }
 


### PR DESCRIPTION
- fix the charts use of 'start of day' unix timestamp to use proper unix time instead of user's browser's timezone