### PR TITLE
text -> number field

### DIFF
--- a/src/views/pages/Liquidity/LiqAdd.js
+++ b/src/views/pages/Liquidity/LiqAdd.js
@@ -562,8 +562,8 @@ const LiqAdd = () => {
                               >
                                 <FormControl
                                   className="text-end ms-0"
-                                  type="text"
-                                  pattern="[0-9]+([\.][0-9]{1,2})?"
+                                  type="number"
+                                  min="0"
                                   placeholder={`${t('add')}...`}
                                   id="addInput1"
                                   autoComplete="off"


### PR DESCRIPTION
remove the text regex and go with number keyboard with a min of zero

make sure we get some locales who use the comma as a decimal point to test on both android and iphone, but i am beginning to remember now, that was only an issue when we were trying to force dots for decimal points and commas for thousand separators on all locales after it was suggested by a community member some time ago.

I suspect it should be fine on all devices, as long as we let the browser choose the locale and the browser matches the user's system locale (keyboard as decided by the system settings, locale/conversion of the number as set by the browser)