### PR TITLE
fixed language popup position on firefox

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   <html>
     <head>


### PR DESCRIPTION
related to this issue #823 

It looks like that the position is fixed by adding `<!DOCTYPE html>` at the beginning of index.html file. Without that, the page works in `Quirks Mode` and this is causing the popup to be rendered not correctly on Firefox. 

Note: it still not fixing the arrow thing

<img width="359" alt="image" src="https://user-images.githubusercontent.com/32012330/178255938-dbb62ce5-e066-45df-a887-5c5df23a4208.png">
