### PR TITLE
Clean up calls

### DIFF
--- a/src/components/WalletSelect/index.js
+++ b/src/components/WalletSelect/index.js
@@ -152,6 +152,7 @@ const WalletSelect = (props) => {
 
   useEffect(() => {
     if (
+      window &&
       !pending &&
       !triedOnce &&
       window.localStorage.getItem('disableWallet') !== '1' &&

--- a/src/containers/Common/Navbar/components/Supply.js
+++ b/src/containers/Common/Navbar/components/Supply.js
@@ -8,6 +8,7 @@ import Overlay from 'react-bootstrap/Overlay'
 import Form from 'react-bootstrap/Form'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import { useDispatch } from 'react-redux'
+import { Link } from 'react-router-dom'
 import { useSparta } from '../../../../store/sparta'
 import { usePool } from '../../../../store/pool'
 import { useWeb3 } from '../../../../store/web3'
@@ -373,6 +374,9 @@ const Supply = () => {
                     : 'Loading...'}
                   <Spacer className="ms-1" size="15" />
                 </Col>
+              </Row>
+              <Row>
+                <Link to="/pu" style={{ height: '10px' }} />
               </Row>
             </Popover.Body>
           </Popover>

--- a/src/store/pool/index.js
+++ b/src/store/pool/index.js
@@ -119,7 +119,7 @@ export const getTokenDetails =
         const { addresses } = getState().app
         let tempArray = []
         for (let i = 0; i < listedTokens.length; i++) {
-          const contract = getTokenContract(listedTokens[i], wallet, rpcs)
+          const contract = getTokenContract(listedTokens[i], null, rpcs)
           tempArray.push(listedTokens[i]) // TOKEN ADDR (1)
           if (wallet.account) {
             if (listedTokens[i] === addresses.bnb) {
@@ -255,7 +255,7 @@ export const getPoolDetails = (wallet) => async (dispatch, getState) => {
           ? curatedPools.includes(listedPools[i].address)
           : false
         const poolContract = validPool
-          ? getPoolContract(listedPools[i].address, wallet, rpcs)
+          ? getPoolContract(listedPools[i].address, null, rpcs)
           : null
         tempArray.push(
           !validPool || !wallet.account

--- a/src/store/sparta/index.js
+++ b/src/store/sparta/index.js
@@ -98,7 +98,7 @@ export const getSpartaGlobalDetails = () => async (dispatch, getState) => {
 export const fallenSpartansCheck = (wallet) => async (dispatch, getState) => {
   dispatch(updateLoading(true))
   const { rpcs } = getState().web3
-  const contract = getFallenSpartansContract(wallet, rpcs)
+  const contract = getFallenSpartansContract(null, rpcs)
   try {
     const claimCheck = await contract.callStatic.getClaim(wallet.account)
     dispatch(updateClaimCheck(claimCheck.toString()))

--- a/src/store/synth/index.js
+++ b/src/store/synth/index.js
@@ -140,7 +140,7 @@ export const getSynthMinting = () => async (dispatch, getState) => {
   const { rpcs } = getState().web3
   try {
     if (rpcs.length > 0) {
-      const contract = getRouterContract(rpcs)
+      const contract = getRouterContract(null, rpcs)
       const synthMinting = await contract.callStatic.synthMinting()
       dispatch(updateSynthMinting(synthMinting))
     }
@@ -199,7 +199,7 @@ export const getSynthDetails = (wallet) => async (dispatch, getState) => {
   try {
     if (synthArray.length > 0) {
       const { rpcs } = getState().web3
-      const contract = getSynthVaultContract(wallet, rpcs)
+      const contract = getSynthVaultContract(null, rpcs)
       let tempArray = []
       for (let i = 0; i < synthArray.length; i++) {
         if (!wallet.account || synthArray[i].address === false) {
@@ -209,7 +209,7 @@ export const getSynthDetails = (wallet) => async (dispatch, getState) => {
         } else {
           const synthContract = getSynthContract(
             synthArray[i].address,
-            wallet,
+            null,
             rpcs,
           )
           tempArray.push(synthContract.callStatic.balanceOf(wallet.account)) // balance
@@ -232,7 +232,7 @@ export const getSynthDetails = (wallet) => async (dispatch, getState) => {
         } else {
           const synthContract = getSynthContract(
             synthArray[i].address,
-            wallet,
+            null,
             rpcs,
           )
           tempArray.push(synthContract.callStatic.collateral()) // lpBalance

--- a/src/store/utils/index.js
+++ b/src/store/utils/index.js
@@ -45,10 +45,10 @@ export const {
  * Returns the pool's details
  * @returns [ tokenAddress | poolAddress | genesis | baseAmount | tokenAmount | baseAmountPooled | tokenAmountPooled | fees | volume | txCount | poolUnits ]
  */
-export const getPoolDetails = (pool, wallet) => async (dispatch, getState) => {
+export const getPoolDetails = (pool) => async (dispatch, getState) => {
   dispatch(updateLoading(true))
   const { rpcs } = getState().web3
-  const contract = getUtilsContract(wallet, rpcs)
+  const contract = getUtilsContract(null, rpcs)
   try {
     const poolDetails = await contract.callStatic.getPoolData(pool)
     dispatch(updatePoolDetails(poolDetails))
@@ -64,10 +64,10 @@ export const getPoolDetails = (pool, wallet) => async (dispatch, getState) => {
  * @param {object} wallet
  * @returns {address} pool
  */
-export const getPool = (token, wallet) => async (dispatch, getState) => {
+export const getPool = (token) => async (dispatch, getState) => {
   dispatch(updateLoading(true))
   const { rpcs } = getState().web3
-  const contract = getUtilsContract(wallet, rpcs)
+  const contract = getUtilsContract(null, rpcs)
   try {
     const pool = await contract.callStatic.getPool(token)
     dispatch(updatePool(pool))
@@ -83,10 +83,10 @@ export const getPool = (token, wallet) => async (dispatch, getState) => {
  * @param {object} wallet
  * @returns {address} synth
  */
-export const getSynth = (token, wallet) => async (dispatch, getState) => {
+export const getSynth = (token) => async (dispatch, getState) => {
   dispatch(updateLoading(true))
   const { rpcs } = getState().web3
-  const contract = getUtilsContract(wallet, rpcs)
+  const contract = getUtilsContract(null, rpcs)
   try {
     const synth = await contract.callStatic.getSynth(token)
     dispatch(updateSynth(synth))

--- a/src/store/web3/index.js
+++ b/src/store/web3/index.js
@@ -212,7 +212,7 @@ export const getAllowance1 =
     const { rpcs } = getState().web3
     try {
       if (rpcs.length > 0) {
-        const contract = getTokenContract(tokenAddress, wallet, rpcs)
+        const contract = getTokenContract(tokenAddress, null, rpcs)
         const allowance1 = await contract.allowance(
           wallet.account,
           contractAddress,
@@ -236,7 +236,7 @@ export const getAllowance2 =
     const { rpcs } = getState().web3
     try {
       if (rpcs.length > 0) {
-        const contract = getTokenContract(tokenAddress, wallet, rpcs)
+        const contract = getTokenContract(tokenAddress, null, rpcs)
         const allowance2 = await contract.allowance(
           wallet.account,
           contractAddress,


### PR DESCRIPTION
BinanceWallet does not allow the use of custom RPCs and appears to be severely rate limited recently.

In reaction to that we went through and made sure any providers that we create are only turned into signers if necessary (therefore we can use a random RPC instead of relying on the BinanceWallet one)

There was only ~8 offending cases that were actually in use, however a couple of them were often batched in as 10-20 calls at a time, so this should make a big difference.

Other than that, BinanceWallet seems to perform all good, so we can close #852