### PR TITLE
add fallback to old copy method

### DIFF
--- a/src/components/Share/ShareLink.js
+++ b/src/components/Share/ShareLink.js
@@ -1,11 +1,20 @@
 import React from 'react'
 
 export const writeToClipboard = async (text) => {
-  try {
-    await navigator.clipboard.writeText(text)
-    // Need to trigger a toast/alert
-  } catch (error) {
-    console.error('write to clipboard error', error)
+  if (!navigator.clipboard) {
+    try {
+      document.execCommand('copy')
+      // Need to trigger a toast/alert
+    } catch (error) {
+      console.error('write to clipboard error', error)
+    }
+  } else {
+    try {
+      await navigator.clipboard.writeText(text)
+      // Need to trigger a toast/alert
+    } catch (error) {
+      console.error('write to clipboard error', error)
+    }
   }
 }
 


### PR DESCRIPTION
added a fallback to document.execCommand('copy') if navigator.clipboard is not found