### PR TITLE
add proper fallback for copy function

### DIFF
--- a/src/components/Share/ShareLink.js
+++ b/src/components/Share/ShareLink.js
@@ -1,17 +1,23 @@
 import React from 'react'
 
-export const writeToClipboard = async (text) => {
-  if (!navigator.clipboard || window.ethereum?.isTrust) {
+export const writeToClipboard = async (targetText) => {
+  if (navigator.clipboard && navigator.permissions) {
     try {
-      document.execCommand('copy')
-      // Need to trigger a toast/alert
+      await navigator.clipboard.writeText(targetText)
     } catch (error) {
       console.error('write to clipboard error', error)
     }
-  } else {
+  } else if (document.queryCommandSupported('copy')) {
     try {
-      await navigator.clipboard.writeText(text)
-      // Need to trigger a toast/alert
+      const newEl = document.createElement('textarea') // Create element to copy
+      newEl.value = targetText // Update the elements value to targetText
+      newEl.style.top = '0' // Avoid scrolling to bottom
+      newEl.style.left = '0' // Avoid scrolling to bottom
+      newEl.style.position = 'fixed' // Avoid scrolling to bottom
+      document.body.appendChild(newEl) // Add the element to body so its visible to the document api
+      newEl.select() // Select the new element
+      document.execCommand('copy') // Copy the value of the new element
+      document.body.removeChild(newEl) // Remove the element from the DOM
     } catch (error) {
       console.error('write to clipboard error', error)
     }
@@ -23,7 +29,7 @@ const ShareLink = (props) => {
 
   return (
     <div
-      onClick={() => writeToClipboard(url)}
+      onClick={() => writeToClipboard(url)} // Need to trigger a toast/alert
       role="button"
       aria-hidden="true"
       className="zoomactive d-inline-block"


### PR DESCRIPTION
- added completed logic to fallback to copy to clipboard using deprecated method
- removed the conditional TrustWallet check (use object & permission checks instead)