### PR TITLE
checks systems-prefered theme -> chnge to dark

### DIFF
--- a/src/providers/Theme/index.js
+++ b/src/providers/Theme/index.js
@@ -1,13 +1,23 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
 const ThemeContext = createContext()
-
+const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)')
 const ThemeProvider = ({ children }) => {
   const [isDark, setIsDark] = useState(false)
 
   // On load
   useEffect(() => {
-    if (window.localStorage.getItem('theme') === 'true') {
+    /* Code below can be used wether to check if user changes his prefered system-theme mid-use Dapp
+     darkThemeMq.addEventListener('change', (e) => {
+      if (e.matches) {
+        setIsDark(true)
+        document.body.classList.toggle('dark-theme', true)
+      } else {
+        setIsDark(false)
+        document.body.classList.toggle('dark-theme', false)
+      }
+    }) */
+    if (!darkThemeMq.matches) {
       setIsDark(true)
       document.body.classList.toggle('dark-theme', true)
     }


### PR DESCRIPTION
OnLoad checks users system-theme settings. If it isnt darkmode it will set the Dapp to darkmode, thus making it the default setting. Added some code for future in case we go towards the prefered theme aproach by user's system setting. Checking it if the user changes it mid-use and changes the Dapp accordingly. 