### PR TITLE
adjusted dapp to suit new gas rates

### DIFF
--- a/src/components/Settings/options.js
+++ b/src/components/Settings/options.js
@@ -1,10 +1,10 @@
 export const defaultSettings = {
-  gasRateMN: '5.01',
+  gasRateMN: '3.01',
   gasRateTN: '10.01',
   slipTol: '1.0',
 }
 // Gas Rates
-export const gasRatesMN = ['5.00', '5.01', '6.00', '7.00', '8.00']
+export const gasRatesMN = ['3.00', '3.01', '4.00', '5.00', '6.00']
 export const gasRatesTN = ['10.00', '10.01', '11.00', '12.00', '13.00']
 // Slip tolerances
 export const slipTols = ['0.1', '0.5', '1.0', '2.5', '5.0']

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -181,7 +181,7 @@
   "gainInfoSingle": "Your NET position based on the sum of the above rows. This is a comparison to if you were to hold USD instead of providing liquidity to the pools (Excluding Harvest Rewards)",
   "gainInfoSingleCoin": "Your NET {{coin}} position based on the sum of the above rows (Excluding Harvest Rewards)",
   "gasRate": "Gas Rate (GWEI)",
-  "gasRateDesc": "Gas is the term used in EVM networks for transaction power. For a transaction to occur, you need to give it some gas, which costs gwei. Mainnet recommended rate is 5 GWEI, you should always confirm the gas rate is correct in your wallet before signing a transaction. (Don't blindly trust the DApp)",
+  "gasRateDesc": "Gas is the term used in EVM networks for transaction power. For a transaction to occur, you need to give it some gas, which costs gwei. Mainnet recommended rate is 3 GWEI, you should always confirm the gas rate is correct in your wallet before signing a transaction. (Don't blindly trust the DApp)",
   "globalFreeze": "Global Freeze",
   "generateFirst": "Generate First",
   "harvest": "Harvest",

--- a/src/store/app/index.js
+++ b/src/store/app/index.js
@@ -64,7 +64,7 @@ export const appSlice = createSlice({
     // sp_positions: window.localStorage.getItem('sp_positions'),
     // sp_synthpositions: window.localStorage.getItem('sp_synthpositions'),
     settings:
-      tryParse(window.localStorage.getItem('sp_settings')) ?? defaultSettings,
+      tryParse(window.localStorage.getItem('sp_settings1')) ?? defaultSettings,
     addresses:
       tryParse(window.localStorage.getItem('sp_addresses')) ??
       changeAddresses(window.localStorage.getItem('sp_chainId') > 56 ? 97 : 56),
@@ -106,7 +106,10 @@ export const appSlice = createSlice({
     },
     updateSettings: (state, action) => {
       state.settings = action.payload
-      window.localStorage.setItem('sp_settings', JSON.stringify(action.payload))
+      window.localStorage.setItem(
+        'sp_settings1',
+        JSON.stringify(action.payload),
+      )
     },
     updateAlertTimestamp: (state, action) => {
       state.alertTimestamp = action.payload


### PR DESCRIPTION
- changed mainnet default gas rate to 3.01 GWEI
- changed mainnet gas rate options to range from 3 - 6 gwei
- changed tooltip to mention 3 GWEI as recommended mainnet rate instead of 5 GWEI
- changed localstorage id from `sp_settings` to `sp_settings1` to force all users to reset settings to default on first load after this change (otherwise would rely on existing users going in and manually change their gas rate in settings)

closes #907 