### PR TITLE
changes to pools page

### DIFF
--- a/src/containers/Common/SocialIcons/index.js
+++ b/src/containers/Common/SocialIcons/index.js
@@ -39,7 +39,7 @@ const SocialIcons = ({ centered }) => (
     >
       <Icon icon="telegram" size="25" />
     </a>
-    <a
+    {/* <a
       href="https://discord.gg/wQggvntnGk"
       target="_blank"
       rel="noreferrer"
@@ -47,7 +47,7 @@ const SocialIcons = ({ centered }) => (
       className="mx-2"
     >
       <Icon icon="discord" size="25" />
-    </a>
+    </a> */}
   </div>
 )
 

--- a/src/containers/Pools/PoolItem.js
+++ b/src/containers/Pools/PoolItem.js
@@ -108,8 +108,13 @@ const PoolItem = ({ asset, daoApy }) => {
   const poolCapTooltip = Tooltip(t, 'poolCap')
   const poolRatioTooltip = Tooltip(t, 'poolRatio')
 
-  const isAtCaps = () =>
-    BN(baseAmount).gt(BN(baseCap).minus(5000000000000000000000))
+  const isAtCaps = () => {
+    if (BN(baseCap).lt('1000000000000000000000000')) {
+      return BN(baseAmount).gt(BN(baseCap).minus('10000000000000000000000'))
+    }
+    return BN(baseAmount).gt(BN(baseCap).minus('50000000000000000000000'))
+  }
+
   const getDepthPC = () => BN(baseAmount).div(asset.baseCap).times(100)
   const getRatioPC = () => BN(safety).times(100)
   const getScaled = () => {

--- a/src/containers/Pools/PoolTableItem.js
+++ b/src/containers/Pools/PoolTableItem.js
@@ -68,8 +68,12 @@ const PoolTableItem = ({ asset, daoApy }) => {
 
   const APY = calcAPY(asset, getFees(), getDivis())
 
-  const isAtCaps = () =>
-    BN(baseAmount).gt(BN(baseCap).minus(5000000000000000000000))
+  const isAtCaps = () => {
+    if (BN(baseCap).lt('1000000000000000000000000')) {
+      return BN(baseAmount).gt(BN(baseCap).minus('10000000000000000000000'))
+    }
+    return BN(baseAmount).gt(BN(baseCap).minus('50000000000000000000000'))
+  }
 
   const getDepthPC = () => BN(baseAmount).div(asset.baseCap).times(100)
 

--- a/src/containers/Pools/SynthItem.js
+++ b/src/containers/Pools/SynthItem.js
@@ -18,7 +18,7 @@ import { calcLiqValue, getSynth } from '../../utils/math/utils'
 
 import styles from './styles.module.scss'
 
-const SynthItem = ({ asset, synthApy }) => {
+const SynthItem = ({ asset }) => {
   const { t } = useTranslation()
   const pool = usePool()
   const synth = useSynth()
@@ -95,7 +95,7 @@ const SynthItem = ({ asset, synthApy }) => {
                 </p>
               </Col>
               <Col className="text-end my-auto">
-                <strong className="text-sm-label mb-0 d-inline-block">
+                {/* <strong className="text-sm-label mb-0 d-inline-block">
                   Synth APY
                 </strong>
                 <p className="output-card">
@@ -108,7 +108,7 @@ const SynthItem = ({ asset, synthApy }) => {
                     </span>
                   </OverlayTrigger>
                   {formatFromUnits(synthApy, 2)}%
-                </p>
+                </p> */}
               </Col>
             </Row>
 
@@ -224,7 +224,7 @@ const SynthItem = ({ asset, synthApy }) => {
                   disabled={!asset.curated}
                   onClick={() => navigate('/vaults?tab=Synth')}
                 >
-                  {t('stake')}
+                  {t('withdraw')}
                 </Button>
               </Col>
               <Col>
@@ -234,7 +234,7 @@ const SynthItem = ({ asset, synthApy }) => {
                   className="w-100"
                   onClick={() => navigate(`/synths?asset2=${tokenAddress}`)}
                 >
-                  {t('forge')}
+                  {t('melt')}
                 </Button>
               </Col>
             </Row>

--- a/src/containers/Pools/SynthTableHeader.js
+++ b/src/containers/Pools/SynthTableHeader.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
-import { Tooltip } from '../../components/Tooltip/index'
-import { Icon } from '../../components/Icons/index'
+// import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+// import { Tooltip } from '../../components/Tooltip/index'
+// import { Icon } from '../../components/Icons/index'
 import styles from './styles.module.scss'
 
 const SynthTableHeader = () => {
@@ -24,14 +24,14 @@ const SynthTableHeader = () => {
           </OverlayTrigger>
         </th> */}
         <th className="d-none d-sm-table-cell">{t('depth')}</th>
-        <th>
+        {/* <th>
           APY
           <OverlayTrigger placement="auto" overlay={Tooltip(t, 'apyVault')}>
             <span role="button">
               <Icon icon="info" size="17" className="ms-1 mb-1" />
             </span>
           </OverlayTrigger>
-        </th>
+        </th> */}
         <th />
       </tr>
     </thead>

--- a/src/containers/Pools/SynthTableItem.js
+++ b/src/containers/Pools/SynthTableItem.js
@@ -15,7 +15,7 @@ import { getSynth } from '../../utils/math/utils'
 // import { stirCauldron } from '../../utils/math/router'
 import { useSynth } from '../../store/synth'
 
-const SynthTableItem = ({ asset, synthApy }) => {
+const SynthTableItem = ({ asset }) => {
   const { t } = useTranslation()
   const pool = usePool()
   const synth = useSynth()
@@ -108,7 +108,7 @@ const SynthTableItem = ({ asset, synthApy }) => {
           %
         </td>
         {/* apy */}
-        <td>{formatFromUnits(synthApy, 2)}%</td>
+        {/* <td>{formatFromUnits(synthApy, 2)}%</td> */}
         {/* actions (buttons) */}
         <td>
           <Row className="text-center mt-2 me-1">
@@ -120,7 +120,7 @@ const SynthTableItem = ({ asset, synthApy }) => {
                 disabled={!asset.curated}
                 onClick={() => navigate('/vaults?tab=Synth')}
               >
-                {t('stake')}
+                {t('withdraw')}
               </Button>
             </Col>
             <Col xs="12" md="6">
@@ -130,7 +130,7 @@ const SynthTableItem = ({ asset, synthApy }) => {
                 className="w-100 mb-2"
                 onClick={() => navigate(`/synths?asset2=${tokenAddress}`)}
               >
-                {t('forge')}
+                {t('melt')}
               </Button>
             </Col>
           </Row>

--- a/src/containers/Pools/index.js
+++ b/src/containers/Pools/index.js
@@ -47,7 +47,7 @@ const Overview = () => {
   const [tableView, setTableView] = useState(true)
 
   const [daoApy, setDaoApy] = useState('0')
-  const [synthApy] = useState('0')
+  // const [synthApy] = useState('0')
   const [arrayPools, setarrayPools] = useState(false)
   const [arrayNewPools, setarrayNewPools] = useState(false)
   const [arraySynths, setarraySynths] = useState(false)
@@ -387,7 +387,7 @@ const Overview = () => {
                         <SynthTableItem
                           key={asset.address}
                           asset={asset}
-                          synthApy={synthApy}
+                          // synthApy={synthApy}
                         />
                       ))}
                   </tbody>
@@ -423,7 +423,7 @@ const Overview = () => {
                           <SynthItem
                             key={asset.address}
                             asset={asset}
-                            synthApy={synthApy}
+                            // synthApy={synthApy}
                           />
                         ))
                       : 'No synths available')}


### PR DESCRIPTION
- removed synth apys from front-end
- changed the `isAtCaps` logic to reflect pool size better with separate logic for pools with < 1M caps and >1M caps
- change synth 'stake' button text label to 'withdraw'
- change synth 'forge' button text label to 'melt'
- remove discord link/icon